### PR TITLE
Generalize autograder configuration file

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,4 @@
 {
-    "course": "CSE-114A-F24",
     "assignment": "00-lambda",
     "server": "http://lighthouse.soe.ucsc.edu",
-    "user": "sslug@ucsc.edu",
-    "pass": "1234567890"
 }


### PR DESCRIPTION
Remove section-specific and user-specific fields. Users will need to specify these themselves (as command-line arguments or by creating their own user config).